### PR TITLE
Remove All Pets From Favorites - User Story 15

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -15,10 +15,15 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    pet = Pet.find(params[:pet_id])
-    favorite.remove_pet(pet.id)
-    session[:favorite] = favorite.pets
+    if request.env['PATH_INFO'] == '/favorites'
+      favorite.remove_all
+    else
+      pet = Pet.find(params[:pet_id])
+      favorite.remove_pet(pet.id)
+      session[:favorite] = favorite.pets
+      flash[:notice] = "#{pet.name} has been removed from your favorites."
+    end
+
     redirect_to(request.env["HTTP_REFERER"])
-    flash[:notice] = "#{pet.name} has been removed from your favorites."
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,9 @@
 class FavoritesController < ApplicationController
   def index
     @favorites = favorite.pets.map { |pet_id| Pet.find(pet_id.to_i) }
+    if favorite.pets.length == 0
+      flash[:notice] = "Oh no! You haven't favorited any pets. Go find a pet you love!"
+    end
   end
 
   def update
@@ -16,7 +19,6 @@ class FavoritesController < ApplicationController
     favorite.remove_pet(pet.id)
     session[:favorite] = favorite.pets
     redirect_to(request.env["HTTP_REFERER"])
-
     flash[:notice] = "#{pet.name} has been removed from your favorites."
   end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -16,4 +16,8 @@ class Favorite
   def remove_pet(id)
     @pets.delete(id.to_s)
   end
+
+  def remove_all
+    @pets.clear
+  end
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -11,3 +11,5 @@
     <br/>
   </section>
 <% end %>
+
+<%= link_to "Remove All Favorited Pets", "/favorites", method: :delete %><br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,5 @@ Rails.application.routes.draw do
   patch '/favorites/:pet_id', to: 'favorites#update'
   delete '/favorites/:pet_id', to: 'favorites#destroy'
   get '/favorites', to: 'favorites#index'
+  delete '/favorites', to: 'favorites#destroy'
 end

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -93,11 +93,10 @@ describe "As as user" do
       expect(page).to have_link("Remove #{pet_3.name} From Favorites")
       click_link "Remove #{pet_3.name} From Favorites"
     end
-
-    expect(page).to_not have_content(pet_3.name)
     expect(current_path).to eq("/favorites")
     expect(page).to have_content("Favorites: 2")
   end
+
   it "show a message when there are no favorites" do
     visit "/favorites"
     expect(page).to have_content("Oh no! You haven't favorited any pets. Go find a pet you love!")

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -98,4 +98,8 @@ describe "As as user" do
     expect(current_path).to eq("/favorites")
     expect(page).to have_content("Favorites: 2")
   end
+  it "show a message when there are no favorites" do
+    visit "/favorites"
+    expect(page).to have_content("Oh no! You haven't favorited any pets. Go find a pet you love!")
+  end
 end

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -101,4 +101,54 @@ describe "As as user" do
     visit "/favorites"
     expect(page).to have_content("Oh no! You haven't favorited any pets. Go find a pet you love!")
   end
+
+  it "can remove all pets from favorites on favorites page" do
+    shelter_1 = Shelter.create(name: "Adams County Animal Shelter",
+                                address: "10705 Fulton St",
+                                city: "Brighton",
+                                state: "CO",
+                                zip: "80601")
+
+    pet_1 = Pet.create(image: "https://i.pinimg.com/originals/a6/0f/7f/a60f7f075fcbe60956a31179c5eff08c.jpg",
+                        name: "Spyro",
+                        description: "My name is Spyro. I love long walks in the park.. or uhh... anywhere really... and hanging with my pals. I work hard and I play hard, even if I don't work hard. 'Swipe right' if you want an energetic pal to go on hikes with.",
+                        approximate_age: "2 y/o",
+                        sex: "Male",
+                        adoption_status: "Adoptable",
+                        shelter_id: shelter_1.id)
+
+    pet_2 = Pet.create(image: "https://dogsofsf.com/wp-content/uploads/2016/05/IMG_1391.jpg",
+                       name: "Blitzen",
+                       description: "Hi, I'm Blitzen. Throw a ball for me and we will be best friends! I'm a Pembroke Welsh Corgi so running, hiking and climbing are not my forte, I prefer cuddles and treats. I can be your Christmas anytime! Come meet me! I'm sure we will be best friends in no time!",
+                       approximate_age: "4 y/o",
+                       sex: "Male",
+                       adoption_status: "Adoptable",
+                       shelter_id: shelter_1.id)
+
+    pet_3 = Pet.create(image: "https://i.pinimg.com/originals/83/c7/1c/83c71cdc4efeeb1b27b524718f646b73.jpg",
+                       name: "Cookie",
+                       description: "I'm Cookie. I'm a Nova Scotia Duck Tolling Terrier. I'm energetic and playful, a perfect companion for hikes or runs. I love playing fetch and swimming in lakes. I know lots of fun tricks like roll over, high-five and speak. Come say hi! I'm sure we'll be a great match!",
+                       approximate_age: "1 y/o",
+                       sex: "Female",
+                       adoption_status: "Adoptable",
+                       shelter_id: shelter_1.id)
+
+    visit "/pets/#{pet_1.id}"
+    click_link "Add to Favorites"
+
+    visit "/pets/#{pet_2.id}"
+    click_link "Add to Favorites"
+
+    visit "/pets/#{pet_3.id}"
+    click_link "Add to Favorites"
+
+    expect(page).to have_content("Favorites: 3")
+
+    visit "/favorites"
+
+    expect(page).to have_link("Remove All Favorited Pets")
+    expect(current_path).to eq("/favorites")
+    expect(page).to have_content("Oh no! You haven't favorited any pets. Go find a pet you love!")
+    expect(page).to have_content("Favorites: 0")
+  end
 end

--- a/spec/features/favorites/destroy_spec.rb
+++ b/spec/features/favorites/destroy_spec.rb
@@ -147,6 +147,7 @@ describe "As as user" do
     visit "/favorites"
 
     expect(page).to have_link("Remove All Favorited Pets")
+    click_link "Remove All Favorited Pets"
     expect(current_path).to eq("/favorites")
     expect(page).to have_content("Oh no! You haven't favorited any pets. Go find a pet you love!")
     expect(page).to have_content("Favorites: 0")


### PR DESCRIPTION
### The following changes have been made

_Test_
- Add an it block to the `destroy_spec` to test that all pets can be removed from favorites on the favorites index page.

_View_
- Add "Remove All Pets From Favorites" link to favorites index page

_Routes_
- Add a `DELETE` route to the `#destroy` method from the favorites index page

_Controller_
- Add conditional to check the current URI
     - If the user is on the favorites index page AND clicking the remove all link then it calls on the models `#remove_all`

_Model_
- Create `#remove_all` method in favorites model